### PR TITLE
Divide build subtasks into steps and also skip signing for all actions except package publish.

### DIFF
--- a/workflow-templates/maven_build.yml
+++ b/workflow-templates/maven_build.yml
@@ -31,5 +31,9 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    - name: Build with Maven
-      run: mvn -e clean test verify --file pom.xml
+    - name: Run linting check - Checkstyle
+      run: mvn -e -"Dgpg.skip" checkstyle:check --file pom.xml
+    - name: Run static code analysis - PMD
+      run: mvn -e -"Dgpg.skip" pmd:check --file pom.xml
+    - name: Run unit tests and code coverage check - JUnit and JaCoCo
+      run: mvn -e test -"Dcheckstyle.skip" -"Dgpg.skip" --file pom.xml

--- a/workflow-templates/maven_linting_check.yml
+++ b/workflow-templates/maven_linting_check.yml
@@ -29,4 +29,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Run linting check - Checkstyle
-        run: mvn -e checkstyle:check --file pom.xml
+        run: mvn -e -"Dgpg.skip" checkstyle:check --file pom.xml

--- a/workflow-templates/maven_static_code_analysis_check.yml
+++ b/workflow-templates/maven_static_code_analysis_check.yml
@@ -29,4 +29,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Run static code analysis - PMD
-        run: mvn -e pmd:check --file pom.xml
+        run: mvn -e -"Dgpg.skip" pmd:check --file pom.xml

--- a/workflow-templates/maven_tests_and_code_coverage_check.yml
+++ b/workflow-templates/maven_tests_and_code_coverage_check.yml
@@ -29,4 +29,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Run unit tests and code coverage check - JUnit and JaCoCo
-        run: mvn -e test -Dcheckstyle.skip --file pom.xml
+        run: mvn -e -"Dgpg.skip" test -"Dcheckstyle.skip" --file pom.xml


### PR DESCRIPTION
## Description
Closes #9.
In the end to end build, each build subtask is a separate step now.
This is done so that the subtasks causing build failure along with the relevant log excerpts can be identified easily.

And also package signing has been skipped for all GitHub actions except the one used to publish to Maven Central.
This is done so that all actions used in PRs based out of user forks don't fail due to lack of access to the padaiyal
organization secrets such as gpg private key and password which are needed for package signing.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** N/A
- [ ] **All methods have documentation comments.** N/A
- [ ] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why. N/A
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why. N/A 
- [ ] **README.md has been updated if needed.** N/A
- [ ] **pom.xml version is set to the latest date** If not, explain why. N/A

## Assignee's Checklist
- [ ] **All GitHub action checks have passed.** N/A
- [x] **All reviewers have approved.** 
- [ ] **Relevant documentation has been updated if needed.** N/A
- [ ] **pom.xml version is set to the latest date** If not, explain why. N/A